### PR TITLE
Fix deprecation warnings

### DIFF
--- a/generator/generator_source.ml
+++ b/generator/generator_source.ml
@@ -1,44 +1,46 @@
 let parse read write path f =
-  let ast = read Format.std_formatter ~tool_name:"ppx_view_generator" path in
+  let ast = read ~tool_name:"ppx_view_generator" path in
   let temp_file = Filename.temp_file "ppx_view" "ast" in
   write temp_file ast;
   let chan = open_in temp_file in
-  let ast = Migrate_parsetree_ast_io.from_channel chan in
+  let ast = Migrate_parsetree.Ast_io.from_channel chan in
   close_in chan;
   match ast with
   | Ok (_filename, ast) -> f ast
   | Error err ->
     let msg =
       match err with
-      | Migrate_parsetree_ast_io.Not_a_binary_ast msg ->
+      | Migrate_parsetree.Ast_io.Not_a_binary_ast msg ->
         Printf.sprintf "not a binary AST (%s)" msg
-      | Migrate_parsetree_ast_io.Unknown_version msg ->
+      | Migrate_parsetree.Ast_io.Unknown_version msg ->
         Printf.sprintf "unknown version (%s)" msg
     in
     failwith msg
 
 let parse_signature path =
-  parse Pparse.parse_interface (Pparse.write_ast Pparse.Signature) path
+  parse Pparse.parse_interface
+    (Pparse.write_ast Pparse.Signature) path
     (function
-      | Migrate_parsetree_ast_io.Intf ((module V), ast) ->
-        (Migrate_parsetree_versions.migrate
+      | Migrate_parsetree.Ast_io.Intf ((module V), ast) ->
+        (Migrate_parsetree.Versions.migrate
            (module V)
            (module Ppx_view_common.Ast_utils.Fixed_ocaml)).copy_signature ast
-      | Migrate_parsetree_ast_io.Impl _ ->
+      | Migrate_parsetree.Ast_io.Impl _ ->
         failwith "unexpected structure")
 
 let parse_structure path =
-  parse Pparse.parse_implementation (Pparse.write_ast Pparse.Structure) path
+  parse Pparse.parse_implementation
+    (Pparse.write_ast Pparse.Structure) path
     (function
-      | Migrate_parsetree_ast_io.Impl ((module V), ast) ->
-        (Migrate_parsetree_versions.migrate
+      | Migrate_parsetree.Ast_io.Impl ((module V), ast) ->
+        (Migrate_parsetree.Versions.migrate
            (module V)
            (module Ppx_view_common.Ast_utils.Fixed_ocaml)).copy_structure ast
-      | Migrate_parsetree_ast_io.Intf _ ->
+      | Migrate_parsetree.Ast_io.Intf _ ->
         failwith "unexpected signature")
 
 let migrate_from_fixed =
-  Migrate_parsetree_versions.migrate
+  Migrate_parsetree.Versions.migrate
     (module Ppx_view_common.Ast_utils.Fixed_ocaml)
     (module Migrate_parsetree.OCaml_current)
 

--- a/parsetree-lib/ast_viewer_utils.ml
+++ b/parsetree-lib/ast_viewer_utils.ml
@@ -4,6 +4,7 @@ open Viewlib
 module Attribute = struct
 
   module StringLocationSet = Set.Make (struct
+      [@@@ocaml.warning "-3"]
       type t = string Location.loc
       let compare = Pervasives.compare
     end)
@@ -282,7 +283,7 @@ let invalid_payload loc _ =
     else
       "invalid payload"
   in
-  raise (Location.(Error (error ~loc msg)))
+  raise (Location.Error (Location.error ~loc msg))
 
 module Payload = struct
   module Match = Make_payload (struct let error _loc = View.error end)

--- a/parsetree-lib/ast_viewer_utils.mli
+++ b/parsetree-lib/ast_viewer_utils.mli
@@ -127,7 +127,7 @@ val register_ppx_driver
    : name:string
   -> ?reset_args:(unit -> unit)
   -> ?args:(Arg.key * Arg.spec * Arg.doc) list
-  -> Migrate_parsetree_versions.OCaml_404.types Migrate_parsetree_driver.rewriter
+  -> Migrate_parsetree.Versions.OCaml_404.types Migrate_parsetree.Driver.rewriter
   -> unit
 
 type cases = Parsetree.case list (* this synonym does not exist before 4.06 *)
@@ -137,12 +137,12 @@ type 'a mapper = 'a -> 'a
 class virtual default_mapper : object
 
     val virtual name        : string
-    val mutable config_opt  : Migrate_parsetree_driver.config  option
-    val mutable cookies_opt : Migrate_parsetree_driver.cookies option
+    val mutable config_opt  : Migrate_parsetree.Driver.config  option
+    val mutable cookies_opt : Migrate_parsetree.Driver.cookies option
     val mutable mapper      : Ast_mapper.mapper
 
-    method config  : Migrate_parsetree_driver.config
-    method cookies : Migrate_parsetree_driver.cookies
+    method config  : Migrate_parsetree.Driver.config
+    method cookies : Migrate_parsetree.Driver.cookies
 
     method attribute               : Parsetree.attribute               mapper
     method attributes              : Parsetree.attributes              mapper


### PR DESCRIPTION
From migrate parsetree and and the stdlib deprecations

Signed-off-by: Rudi Grinberg <rudi.grinberg@gmail.com>